### PR TITLE
Removes references to being able to set DataGridCell.IsReadOnly property

### DIFF
--- a/xml/System.Windows.Controls/DataGrid.xml
+++ b/xml/System.Windows.Controls/DataGrid.xml
@@ -3083,7 +3083,7 @@
           <format type="text/markdown"><![CDATA[
 
 ## Remarks
- Set the <xref:System.Windows.Controls.DataGrid.IsReadOnly%2A> property to `true` to make all the cells in the <xref:System.Windows.Controls.DataGrid> read-only. To make individual columns or cells read-only, set the <xref:System.Windows.Controls.DataGridColumn.IsReadOnly%2A?displayProperty=nameWithType> or <xref:System.Windows.Controls.DataGridCell.IsReadOnly%2A?displayProperty=nameWithType> properties. If a conflict exists between the settings at the <xref:System.Windows.Controls.DataGrid>, column, or cell levels, a value of `true` takes precedence over a value of `false`.
+ Set the <xref:System.Windows.Controls.DataGrid.IsReadOnly%2A> property to `true` to make all the cells in the <xref:System.Windows.Controls.DataGrid> read-only. To make individual columns read-only, set the <xref:System.Windows.Controls.DataGridColumn.IsReadOnly%2A?displayProperty=nameWithType> property. If a conflict exists between the settings at the <xref:System.Windows.Controls.DataGrid>, column, or cell levels, a value of `true` takes precedence over a value of `false`.
 
  If this property is set to `true` while the control is in editing mode, all pending edits are discarded.
 

--- a/xml/System.Windows.Controls/DataGridCell.xml
+++ b/xml/System.Windows.Controls/DataGridCell.xml
@@ -206,7 +206,7 @@
           <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
- Set the <xref:System.Windows.Controls.DataGridCell.IsReadOnly%2A> property to `true` to make an individual cell read-only. Set the <xref:System.Windows.Controls.DataGridColumn.IsReadOnly%2A?displayProperty=nameWithType> property to `true` to make all cells in an individual column read-only. Set the <xref:System.Windows.Controls.DataGrid.IsReadOnly%2A?displayProperty=nameWithType> property to `true` to make all cells in the <xref:System.Windows.Controls.DataGrid> read-only If there is a conflict between the settings at the <xref:System.Windows.Controls.DataGrid>, column, and cell levels, a value of `true` takes precedence over a value of `false`.  
+ Set the <xref:System.Windows.Controls.DataGridColumn.IsReadOnly%2A?displayProperty=nameWithType> property to `true` to make all cells in an individual column read-only. Set the <xref:System.Windows.Controls.DataGrid.IsReadOnly%2A?displayProperty=nameWithType> property to `true` to make all cells in the <xref:System.Windows.Controls.DataGrid> read-only If there is a conflict between the settings at the <xref:System.Windows.Controls.DataGrid>, column, and cell levels, a value of `true` takes precedence over a value of `false`.  
   
  ]]></format>
         </remarks>


### PR DESCRIPTION
## Summary

Twice, these docs mention that users are able to set DataGridCell.IsReadOnly to make one cell read-only. This is incorrect, as this property is get-only.